### PR TITLE
[Chore] - PR 알림 디스코드 전송 설정

### DIFF
--- a/.github/workflows /pr-discord-notify.yml
+++ b/.github/workflows /pr-discord-notify.yml
@@ -1,0 +1,29 @@
+name: PR 알림 디스코드 전송
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  notify-discord:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 리뷰어 매핑 및 메시지 생성
+        id: set-message
+        run: |
+          AUTHOR="${{ github.actor }}"
+          if [ "$AUTHOR" = "Gun06" ]; then
+            MESSAGE="<@370855858260672512>, <@287923007425478668>, <@416973946064338954>, <@371157588387168257> 님! 재건님이 PR을 열었어요! 리뷰 부탁드려요 👉 ${{ github.event.pull_request.html_url }}"
+          else
+            MESSAGE="새로운 PR이 생성되었습니다! 리뷰 부탁드려요 👉 ${{ github.event.pull_request.html_url }}"
+          fi
+          echo "message=$MESSAGE" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: 디스코드로 메시지 전송
+        uses: tsickert/discord-webhook@v1.0.0
+        with:
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
+          content: ${{ steps.set-message.outputs.message }}
+          username: "LPick PR Bot"
+          avatar-url: "https://i.pinimg.com/736x/f9/b0/31/f9b031356a9b2199651d3672aa5a4643.jpg"


### PR DESCRIPTION
# 📌 PR 제목
> [Chore] - PR 생성 시 디스코드 멘션 알림 기능 추가

## ✨ 변경/추가된 기능 요약
- AI 파트에서 PR 생성 시 디스코드에서 모든 멤버를 태그하도록 GitHub Actions를 구성했습니다.

## ✅ 주요 작업 내역
- [x] `.github/workflows/pr-discord-notify.yml` 생성
- [x] Discord Webhook을 통해 멘션 메시지 전송
- [x] 메시지에 커스텀 봇 이름(`LPick Bot`)과 프로필 이미지 적용
- [x] `DISCORD_WEBHOOK` secret 등록 및 테스트 완료

## 🧪 테스트 결과
- [x] 테스트용 개인 레포에서 PR 생성 시 리뷰 대상자에게 디스코드 멘션 알림 정상 작동 확인
- [x] 디스코드 메시지에 프로필 이미지 및 유저 태그 정상 적용됨

## 📚 참고 자료
- GitHub Actions 공식 문서 (`$GITHUB_OUTPUT`, secrets 사용법 등)
- tsickert/discord-webhook@v1.0.0 액션 사용
- Discord Webhook 설정 가이드

## 👀 리뷰어에게 하고 싶은 말
- 리뷰어는 현재 재건님을 제외한 모든 팀원에게 알림이 가도록 설정했으나, 원하신다면 변경 가능합니다.
- 프로필 이미지로 사용한 그림은 제 취향대로 등록했습니다.